### PR TITLE
fix(server): reference shared modules from parent directory

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,10 @@ import session from "express-session";
 import MongoStore from "connect-mongo";
 import bcrypt from "bcrypt";
 import { storage } from "./storage";
-import { insertBookingSchema, insertReviewSchema } from "@shared/schema";
+import {
+  insertBookingSchema,
+  insertReviewSchema,
+} from "../shared/schema.js";
 import { whatsappService } from "./whatsapp-service";
 import { z } from "zod";
 import {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13,7 +13,7 @@ import type {
   InsertReview,
   BookingWithActivity,
   ReviewWithActivity,
-} from "../shared/schema";
+} from "../shared/schema.js";
 
 // MongoDB connection string - ensure proper format
 const DATABASE_URL = process.env.MONGODB_URI || process.env.MONGO_URL;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "allowJs": true,


### PR DESCRIPTION
## Summary
- fix server imports to load schema from the shared directory
- switch server TypeScript config to NodeNext and include shared sources

## Testing
- `npm run check` *(fails: Type 'string' is not assignable to type 'number')*
- `npx tsc -p server/tsconfig.json` *(fails: Parameter 'booking' implicitly has an 'any' type)*
- `npm run build` *(fails: No matching export in "server/vite.ts" for import "createServer")*

------
https://chatgpt.com/codex/tasks/task_e_689539addd848331a901035da110425a